### PR TITLE
Print qt6 version required

### DIFF
--- a/configure
+++ b/configure
@@ -1695,7 +1695,7 @@ EOF
       fail
     fi
   else
-    log_failure "qt6 not found"
+    log_failure "qt6 >= $QT6MAJ.$QT6MIN.0 not found"
     fail
   fi
 }


### PR DESCRIPTION
will print 
```
Checking for Qt6: 
  ** qt6 >= 6.8.0 not found!
```

instead qt6 not found on RHEL9 which just have one qt6 lower of 6.8.0 