### PR TITLE
Fix ubuntu unattended installation with guest additions

### DIFF
--- a/src/VBox/Main/UnattendedTemplates/debian_postinstall.sh
+++ b/src/VBox/Main/UnattendedTemplates/debian_postinstall.sh
@@ -229,6 +229,10 @@ log_command_in_target /bin/bash "${MY_CHROOT_CDROM}/vboxadditions/@@VBOX_INSERT_
 log_command_in_target /bin/bash -c "udevadm control --reload-rules" # GAs doesn't yet do this.
 log_command_in_target /bin/bash -c "udevadm trigger"                 # (ditto)
 MY_IGNORE_EXITCODE=
+# Currently in Ubuntu, the vboxsf group does not exist when this script executes.
+# But if it does in the future, the --force option will ensure the command
+# still succeeds.
+log_command_in_target groupadd --force --system vboxsf
 log_command_in_target usermod -a -G vboxsf "@@VBOX_INSERT_USER_LOGIN@@"
 @@VBOX_COND_END@@
 

--- a/src/VBox/Main/UnattendedTemplates/ubuntu_autoinstall_user_data
+++ b/src/VBox/Main/UnattendedTemplates/ubuntu_autoinstall_user_data
@@ -10,6 +10,12 @@ autoinstall:
   keyboard:
     layout: us
 
+  identity:
+    realname: '@@VBOX_INSERT_USER_FULL_NAME@@'
+    username: '@@VBOX_INSERT_USER_LOGIN@@'
+    password: '@@VBOX_INSERT_USER_PASSWORD_SHACRYPT512@@'
+    hostname: '@@VBOX_INSERT_HOSTNAME_WITHOUT_DOMAIN@@'
+
   shutdown: reboot
 
   storage:
@@ -40,7 +46,7 @@ autoinstall:
   # Additional cloud-init configuration affecting the target system can be supplied
   # underneath a user-data section inside of autoinstall.
   user-data:
-    hostname: '@@VBOX_INSERT_HOSTNAME_WITHOUT_DOMAIN@@'
+
     users:
       - name: root
         primary_group: root
@@ -48,19 +54,6 @@ autoinstall:
         lock-passwd: false
         passwd: '@@VBOX_INSERT_USER_PASSWORD_SHACRYPT512@@'
         uid: 0
-
-      - name: '@@VBOX_INSERT_USER_LOGIN@@'
-        gecos: '@@VBOX_INSERT_USER_LOGIN@@'
-        primary_group: '@@VBOX_INSERT_USER_LOGIN@@'
-@@VBOX_COND_IS_INSTALLING_ADDITIONS@@
-        groups: sudo, vboxsf
-@@VBOX_COND_END@@
-@@VBOX_COND_IS_NOT_INSTALLING_ADDITIONS@@
-        groups: sudo
-@@VBOX_COND_END@@
-        lock-passwd: false
-        shell: /bin/bash
-        passwd: '@@VBOX_INSERT_USER_PASSWORD_SHACRYPT512@@'
 
 @@VBOX_COND_IS_RTC_USING_UTC@@
     timezone: Etc/UTC


### PR DESCRIPTION
The installer for Ubuntu 26.04 now has the ability to create users before first boot [1]. With relevant changes to VirtualBox, it will fix the inability to install unattended when Guest Additions are also installed (see ticketref:22278).

But for that to work, we need the user parameters to be specified in the identity section, not in the user-data section (which is still processed by cloud-init on first boot).

In addition, we need to make sure the `vboxsf` group exists before calling `usermod -aG vboxsf [...]`.

I don't have access to bugref:10878 so I can't tell why the user information were moved from identity to cloud-init's user-data in the first place. Please let me know if it was fixing something important?

I've tested these two patches and was able to successfully install the current daily Ubuntu 26.04 ISO with Guest Additions.
https://cdimage.ubuntu.com/ubuntu-server/daily-live/20251214/
(the ISO will be removed in a few day, but the current daily is available at https://cdimage.ubuntu.com/ubuntu-server/daily-live/current/).

[ticketref:22278](
https://www.virtualbox.org/ticket/22278)

[1] https://github.com/canonical/subiquity/pull/2263