### PR TITLE
fix: infinite loop in vsscanf whitespace processing

### DIFF
--- a/src/VBox/Runtime/common/string/nocrt-vsscanf.cpp
+++ b/src/VBox/Runtime/common/string/nocrt-vsscanf.cpp
@@ -217,7 +217,7 @@ int RT_NOCRT(vsscanf)(const char *pszString, const char *pszFormat, va_list va)
                 while (RT_C_IS_SPACE(*pszFormat))
                     pszFormat++;
                 while (RT_C_IS_SPACE(*pszString))
-                    pszFormat++;
+                    pszString++;
                 break;
 
             /*


### PR DESCRIPTION
Resolves #501 

Fixes an infinite loop within the `vsscanf` function due to incrementing the incorrect variable when processing whitespace. While the loop correctly skipped whitespace in the format string, this loop was only caused by whitespace in the input string.