### PR TITLE
GUI: Add Swedish (sv) to approved languages

### DIFF
--- a/src/VBox/Frontends/VirtualBox/nls/ApprovedLanguages.kmk
+++ b/src/VBox/Frontends/VirtualBox/nls/ApprovedLanguages.kmk
@@ -53,6 +53,7 @@ VBOX_APPROVED_GUI_LANGUAGES := \
 	ru \
 	sk \
 	sl \
+	sv \
 	th \
 	tr \
 	uk \


### PR DESCRIPTION
## Summary
The Swedish translation (`VirtualBox_sv.ts`) exists and has been maintained for years (see ticket #17708). However, Swedish is currently not in the approved languages list, which means the translation is not included in official releases.

This PR adds Swedish (`sv`) to `ApprovedLanguages.kmk` so that it will be compiled and included in VirtualBox releases.

## Changes
- Added `sv` to `VBOX_APPROVED_GUI_LANGUAGES` in alphabetical order (between `sl` and `th`)

## Related
- Ticket: https://www.virtualbox.org/ticket/17708

## Testing
The Swedish translation file `VirtualBox_sv.ts` already exists and passes Qt's `lrelease` without errors.