### PR TITLE
  VRDP: Fix incorrect index check in QueryClientMonitorRect

### DIFF
--- a/src/VBox/RDP/server/vrdpdmap.cpp
+++ b/src/VBox/RDP/server/vrdpdmap.cpp
@@ -690,7 +690,7 @@ VRDPClientDesktopMapMultiMon::VRDPClientDesktopMapMultiMon(VRDPTP *pTP)
 
 /* virtual */ void VRDPClientDesktopMapMultiMon::QueryClientMonitorRect (unsigned uScreenId, RGNRECT *pRect)
 {
-    if (uScreenId > m_cMonitors)
+    if (uScreenId >= m_cMonitors)
     {
         pRect->x = 0;
         pRect->y = 0;


### PR DESCRIPTION
## Description
QueryClientMonitorRect uses `>` instead of `>=` to validate `uScreenId`, allowing an out-of-range access to `m_paRects` when the server has more monitors than the client reported. The adjacent IsScreenMatched already uses '>=' correctly.


## Analysis
`m_paRects` is allocated with `m_cMonitors` elements (valid indices `0` to `m_cMonitors - 1`) in `CalculateClientRect` (line 662-686). When `uScreenId == m_cMonitors`, the guard passes and `m_paRects[m_cMonitors]` accesses past the array.

https://github.com/VirtualBox/virtualbox/blob/354a83f2e4199b165792585618087e7ac906f836/src/VBox/RDP/server/vrdpdmap.cpp#L691-L703
