### PR TITLE
correct issue where VRDEServerInfo gets changed but VRDEServerChangedEvent does not happen.

### DIFF
--- a/src/VBox/Main/src-client/ConsoleVRDPServer.cpp
+++ b/src/VBox/Main/src-client/ConsoleVRDPServer.cpp
@@ -961,6 +961,8 @@ DECLCALLBACK(void) ConsoleVRDPServer::VRDPCallbackClientConnect(void *pvCallback
     if (pVRDE)
         pVRDE->onVRDEClientConnect(u32ClientId);
 #endif
+
+    pServer->mConsole->i_onVRDEServerInfoChange();
 }
 
 DECLCALLBACK(void) ConsoleVRDPServer::VRDPCallbackClientDisconnect(void *pvCallback, uint32_t u32ClientId,
@@ -992,6 +994,8 @@ DECLCALLBACK(void) ConsoleVRDPServer::VRDPCallbackClientDisconnect(void *pvCallb
         /* Features which should be enabled only if there is a client. */
         pServer->remote3DRedirect(false);
     }
+
+    pServer->mConsole->i_onVRDEServerInfoChange();
 }
 
 DECLCALLBACK(int) ConsoleVRDPServer::VRDPCallbackIntercept(void *pvCallback, uint32_t u32ClientId, uint32_t fu32Intercept,


### PR DESCRIPTION
Whenever a client connected or disconnected to VRDP server, several attributes in VRDEServerInfo got changed, but IVRDEServerChangedEvent did not fire.  Added call to i_onVRDEServerInfoChange() in functions "VRDPCallbackClientConnect" and "VRDPCallbackClientDisconnect".