### PR TITLE
add ability to check if DHCP is running

### DIFF
--- a/src/VBox/Main/idl/VirtualBox.xidl
+++ b/src/VBox/Main/idl/VirtualBox.xidl
@@ -2539,6 +2539,12 @@
       </desc>
     </attribute>
 
+    <attribute name="running" type="boolean" readonly="yes">
+      <desc>
+        specifies if the DHCP server is running
+      </desc>
+    </attribute>
+
     <attribute name="IPAddress" type="wstring" readonly="yes">
       <desc>
         specifies server IP

--- a/src/VBox/Main/include/DHCPServerImpl.h
+++ b/src/VBox/Main/include/DHCPServerImpl.h
@@ -87,6 +87,7 @@ private:
     HRESULT getEventSource(ComPtr<IEventSource> &aEventSource) RT_OVERRIDE;
     HRESULT getEnabled(BOOL *aEnabled) RT_OVERRIDE;
     HRESULT setEnabled(BOOL aEnabled) RT_OVERRIDE;
+    HRESULT getRunning(BOOL *aRunning) RT_OVERRIDE;
     HRESULT getIPAddress(com::Utf8Str &aIPAddress) RT_OVERRIDE;
     HRESULT getNetworkMask(com::Utf8Str &aNetworkMask) RT_OVERRIDE;
     HRESULT getNetworkName(com::Utf8Str &aName) RT_OVERRIDE;

--- a/src/VBox/Main/src-server/DHCPServerImpl.cpp
+++ b/src/VBox/Main/src-server/DHCPServerImpl.cpp
@@ -477,6 +477,14 @@ HRESULT DHCPServer::setEnabled(BOOL aEnabled)
 }
 
 
+HRESULT DHCPServer::getRunning(BOOL *aRunning)
+{
+    AutoReadLock alock(this COMMA_LOCKVAL_SRC_POS);
+    *aRunning = m->dhcp.isRunning();
+    return S_OK;
+}
+
+
 HRESULT DHCPServer::getIPAddress(com::Utf8Str &aIPAddress)
 {
     AutoReadLock alock(this COMMA_LOCKVAL_SRC_POS);


### PR DESCRIPTION
when making a change to a DHCP server, returns an error if server is running and cannot make the change.  This allows checking if server is running before attempting to make the changes