### PR TITLE
Expand ARMv8 MMIO32 for 256 MiB VMSVGA VRAM

### DIFF
--- a/src/VBox/Main/src-client/ConsoleImplConfigArmV8.cpp
+++ b/src/VBox/Main/src-client/ConsoleImplConfigArmV8.cpp
@@ -820,7 +820,13 @@ int Console::i_configConstructorArmV8(PUVM pUVM, PVM pVM, PCVMMR3VTABLE pVMM, Au
         hrc = pResMgr->assignMmioRegionAligned("pci-pio",    _64K, _64K, &GCPhysMmioStart,   &cbMmio, false /*fOnly32Bit*/); H();
         hrc = pResMgr->assignMmioRegion(       "pci-ecam",   16 * _1M,   &GCPhysPciMmioEcam, &cbPciMmioEcam);              H();
         hrc = pResMgr->assignMmio64Region(     "pci-mmio",   _2G,        &GCPhysPciMmio,     &cbPciMmio);                  H();
-        hrc = pResMgr->assignMmio32Region(     "pci-mmio32", _256M,      &GCPhysPciMmio32,   &cbPciMmio32);                H();
+        /*
+         * Keep enough 32-bit PCI MMIO space for a 256 MB VMSVGA VRAM BAR and
+         * the VMSVGA3 MMIO BAR.  448 MB places the aperture at the required
+         * 256 MB boundary while the ARMv8 platform still reserves the top of
+         * the low 512 MB MMIO hole for non-PCI platform devices.
+         */
+        hrc = pResMgr->assignMmio32Region(     "pci-mmio32", 448 * _1M,  &GCPhysPciMmio32,   &cbPciMmio32);                H();
 
         InsertConfigNode(pDevices, "pci-generic-ecam",  &pDev);
         InsertConfigNode(pDev,     "0",            &pInst);


### PR DESCRIPTION
## Summary

Expand the Armv8 PCI 32-bit MMIO aperture from 256 MiB to 448 MiB.

The source change is one value in the Armv8 machine configuration. The accompanying comment explains the alignment/layout constraint.

## Why

A VMSVGA guest configured with 256 MiB VRAM needs a 256 MiB prefetchable VRAM BAR as well as the VMSVGA device MMIO BAR in low PCI address space. The existing 256 MiB Armv8 aperture cannot contain both.

A 448 MiB request is placed by the resource manager at the required 256 MiB-aligned `0xe0000000` base and ends at `0xfbffffff`, below the platform devices already reserved at the top of the low MMIO hole.

## Minimal reproduction

Host/guest configuration:

- macOS Arm64 host
- Windows 11 Arm guest
- VMSVGA with 3D acceleration enabled
- `--vram 256`

After starting the current patched build, inspect `VBox.log`:

```sh
rg "pci-mmio32|VRamSize|VMSVGA3dEnabled|VMSVGAEnabled" "$HOME/VirtualBox VMs/Win11/Logs/VBox.log"
```

Current patched result:

```text
00000000e0000000 - 00000000fbffffff (469762048) MMIO pci-mmio32
VMSVGA3dEnabled       <integer> = 0x0000000000000001 (1)
VMSVGAEnabled         <integer> = 0x0000000000000001 (1)
VRamSize              <integer> = 0x0000000010000000 (268435456, 256.0 MiB)
```

The same guest reaches Guest Additions run level 3 and a 5760x3240x32 mode on the current integrated build.

## Validation status

- Rebased independently on `origin/main` at `5ac81eda707fcf3fcb49f9281401ceac0fc70f4a`.
- One source file, one functional value change; `git diff --check` passes.
- Included in a clean Darwin/Arm full build and a strictly signed staged app.
- Patched runtime log confirms the 448 MiB aperture, 256 MiB VRAM, VMSVGA, and 3D configuration shown above.
- The negative runtime A/B with the aperture change removed is still required before this should be merged. Exact failure/log output from that run will be added rather than inferred.

Refs #742.