### PR TITLE
GUI: draw framebuffer updates without temporary pixmaps

### DIFF
--- a/src/VBox/Frontends/VirtualBox/src/runtime/UIFrameBuffer.cpp
+++ b/src/VBox/Frontends/VirtualBox/src/runtime/UIFrameBuffer.cpp
@@ -1441,31 +1441,25 @@ void UIFrameBufferPrivate::drawImageRect(QPainter &painter, const QImage &image,
                                          int iContentsShiftX, int iContentsShiftY,
                                          double dDevicePixelRatio)
 {
-    /* Calculate offset: */
-    const size_t offset = (rect.x() + iContentsShiftX) * image.depth() / 8 +
-                          (rect.y() + iContentsShiftY) * image.bytesPerLine();
-
     /* Restrain boundaries: */
     const int iSubImageWidth = qMin(rect.width(), image.width() - rect.x() - iContentsShiftX);
     const int iSubImageHeight = qMin(rect.height(), image.height() - rect.y() - iContentsShiftY);
+    if (   iSubImageWidth <= 0
+        || iSubImageHeight <= 0)
+        return;
 
-    /* Create sub-image (no copy involved): */
-    QImage subImage = QImage(image.bits() + offset,
-                             iSubImageWidth, iSubImageHeight,
-                             image.bytesPerLine(), image.format());
-
-    /* Create sub-pixmap on the basis of sub-image above (1st copy involved): */
-    QPixmap subPixmap = QPixmap::fromImage(subImage);
-    /* Take the device-pixel-ratio into account: */
-    subPixmap.setDevicePixelRatio(dDevicePixelRatio);
-
-    /* Which point we should draw corresponding sub-pixmap? */
+    /* Which point we should draw the image at? */
     QPoint paintPoint = rect.topLeft();
     /* Take the device-pixel-ratio into account: */
     paintPoint /= dDevicePixelRatio;
 
-    /* Draw sub-pixmap: */
-    painter.drawPixmap(paintPoint, subPixmap);
+    /* Draw directly from the source image to avoid materializing a temporary pixmap for every update rectangle. */
+    const QRect sourceRect(rect.x() + iContentsShiftX, rect.y() + iContentsShiftY,
+                           iSubImageWidth, iSubImageHeight);
+    const QRectF targetRect(QPointF(paintPoint),
+                            QSizeF((double)iSubImageWidth / dDevicePixelRatio,
+                                   (double)iSubImageHeight / dDevicePixelRatio));
+    painter.drawImage(targetRect, image, sourceRect);
 }
 
 /* static */


### PR DESCRIPTION
## Summary

Draw framebuffer update rectangles directly from the backing `QImage` instead of constructing a temporary `QImage` view and converting it to a `QPixmap` for every painted rectangle.

The direct `QPainter::drawImage` call preserves the existing source rectangle, logical target position, and device-pixel-ratio scaling. The patch is confined to `UIFrameBufferPrivate::drawImageRect`; it does not alter Dock previews, opacity, background clearing, widget attributes, update scheduling, or platform policy.

## Scope

This is a draft Qt frontend performance candidate, not a functional prerequisite for the Retina/HiDPI work tracked by #742. It should remain draft—and should be closed if an isolated current-main A/B comparison does not show a repeatable benefit.

## Benchmark source

The validation tool is the fixed [`dxmtbench`](https://github.com/moreaki/dxmtbench) functional/performance harness. Performance samples are admissible only after the same run passes its browser framebuffer, guest screenshot, host presentation/signature, launch, and graphics-log gates.

## Validation

- `git diff --check`: passed.
- Full clean Darwin/Arm64 build from current `origin/main` with this patch in the integrated functional stack: pending after the final minimization.
- Static geometry audit: the source origin and clipped dimensions match the former sub-image; the target dimensions divide by the same device-pixel ratio formerly assigned to the temporary pixmap.
- Runtime correctness and isolated performance A/B at 3840x2160: pending.

Earlier measurements covered a larger combined patch and are not evidence for this minimized PR.

Refs #742.
