### PR TITLE
GUI: resend guest resize on macOS fullscreen transition

### DIFF
--- a/src/VBox/Frontends/VirtualBox/src/runtime/fullscreen/UIMachineViewFullscreen.cpp
+++ b/src/VBox/Frontends/VirtualBox/src/runtime/fullscreen/UIMachineViewFullscreen.cpp
@@ -77,6 +77,10 @@ bool UIMachineViewFullscreen::eventFilter(QObject *pWatched, QEvent *pEvent)
 
                 /* Recalculate maximum guest size: */
                 setMaximumGuestSize();
+#ifdef VBOX_WS_MAC
+                if (m_fGuestAutoresizeEnabled && uimachine()->isGuestSupportsGraphics())
+                    sltPerformGuestResize(pResizeEvent->size());
+#endif
 
                 break;
             }


### PR DESCRIPTION
## Summary

When the macOS fullscreen machine view reaches its calculated maximum size, call the existing guest-resize helper if guest autoresize is enabled and the guest supports graphics.

The change is four macOS-only lines in `UIMachineViewFullscreen::eventFilter`. It does not add a new scaling calculation: `sltPerformGuestResize` already converts the host logical geometry to Retina backing pixels.

## Narrow premise

The suspected failure is a **windowed-to-fullscreen transition** of an already-running guest. Reproduction must therefore use this sequence:

1. start the Windows 11 Arm guest windowed at 3840x2160;
2. wait for Guest Additions run level 3;
3. confirm guest autoresize is enabled;
4. enter macOS fullscreen;
5. record the resulting `VideoMode` and a `screenshotpng`;
6. repeat with the otherwise identical four-line change removed.

Starting the VM directly with `VirtualBoxVM --startvm Win11 --fullscreen` is **not** a valid A/B for this PR. In the clean current-main-based comparison, both patched and unpatched variants reached 5760x3240 during startup through the existing initialization path.

## Validation status

Completed:

- rebased independently on `origin/main` at `5ac81eda707fcf3fcb49f9281401ceac0fc70f4a`;
- one source file, four added lines, macOS-only guard;
- `git diff --check` passes;
- compiles and links in the current Qt 6.11.1 Darwin/Arm `VirtualBoxVM` target;
- the strictly signed patched app starts the guest with VMSVGA/3D, reaches Guest Additions level 3, reports `VideoMode="5760,3240,32"@0,0 1`, and produces a 5760x3240 framebuffer screenshot.

Still required:

- the causal windowed 3840x2160 -> fullscreen transition A/B described above. The prior direct-fullscreen screenshot is retained only as historical functional evidence and has been explicitly withdrawn as proof of this patch.

This PR should be closed if the controlled transition produces the same result without the change.

Refs #742.