### PR TITLE
Darwin: fix current macOS/Arm build and XPCOM runtime

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -725,6 +725,9 @@ def compileAndRun(sName, asIncPaths, asLibPaths, asIncFiles, asLibFiles, \
         asCmd.extend( [ sFileSource ] );
         asCmd.extend( [ '/Fe:' + sFileImage ] );
     else: # Non-Windows
+        if    enmBuildTarget == BuildTarget.DARWIN \
+          and g_oEnv['VBOX_PATH_MACOSX_SDK']:
+            asCmd.extend([ '-isysroot', g_oEnv['VBOX_PATH_MACOSX_SDK'] ]);
         if asIncPaths:
             for sIncPath in asIncPaths:
                 asCmd.extend( [ f'-I{sIncPath}' ] );
@@ -1414,8 +1417,8 @@ class LibraryCheck(CheckBase):
         # macOS (Darwin)
         #
         elif self.enmBuildTarget == BuildTarget.DARWIN:
-            asPaths.extend([ '/opt/homebrew/include',
-                             os.path.join(g_oEnv['VBOX_PATH_MACOSX_SDK'], 'usr', 'include', 'c++', 'v1') ]);
+            asPaths.extend([ os.path.join(g_oEnv['VBOX_PATH_MACOSX_SDK'], 'usr', 'include', 'c++', 'v1'),
+                             '/opt/homebrew/include' ]);
 
         #
         # Linux
@@ -1764,8 +1767,12 @@ class LibraryCheck(CheckBase):
         sPathBin = None;
         sPathLibExec = None;
 
-        # Check if we have our own pre-compiled Qt in tools first.
-        sPathBase = self.getToolPath();
+        # Check if we have our own pre-compiled Qt in tools first.  A custom
+        # Darwin path may point at a normal framework installation instead.
+        if self.enmBuildTarget == BuildTarget.DARWIN and self.sRootPath:
+            sPathBase = None;
+        else:
+            sPathBase = self.getToolPath();
         if sPathBase:
             self.asLibFiles = [ 'libQt6CoreVBox' ];
             g_oEnv.set('VBOX_WITH_ORACLE_QT', '1');
@@ -1803,10 +1810,11 @@ class LibraryCheck(CheckBase):
 
                 # Search for the library file.
                 # Note: Ordered by precedence. Do not change!
-                asPath = [ sPathBase,
-                        getPackagePath('qt@6')[1],
-                        '/System/Library',
-                        '/Library' ];
+                asPath = [ self.sRootPath,
+                           sPathBase,
+                           getPackagePath('qt@6')[1],
+                           '/System/Library',
+                           '/Library' ];
                 sPathFramework = None;
                 for sPathBase in asPath:
                     if not sPathBase: # No custom path? Skip.
@@ -1825,23 +1833,33 @@ class LibraryCheck(CheckBase):
                         break;
 
                 if sPathFramework:
+                    sPathFrameworkParent = os.path.dirname(sPathFramework);
                     # We need to clear the library defined the the LibraryCheck definition
                     # -- macOS uses the framework concept instead.
                     self.asLibFiles = [];
-                    self.asLibPaths.insert(0, sPathFramework);
+                    self.asLibPaths.insert(0, sPathFrameworkParent);
                     # Include the framework headers.
-                    self.asIncPaths.insert(0, f'{sPathBase}/lib/QtCore.framework/Headers');
+                    self.asIncPaths.insert(0, os.path.join(sPathFramework, 'Headers'));
                     # More stuff needed in order to get it linked.
-                    self.asLinkerArgs.extend([ '-std=c++17', '-framework', 'QtCore', '-F', f'{sPathBase}/lib', '-g', '-O', '-Wall' ]);
+                    self.asCompilerArgs.extend([ '-F', sPathFrameworkParent ]);
+                    self.asLinkerArgs.extend([ '-std=c++17', '-framework', 'QtCore', '-F', sPathFrameworkParent, '-g', '-O', '-Wall' ]);
 
         sPkgName = 'Qt6Core'; ## @todo Make the code generic once we have similar SDKs.
         if sPathBase:
             g_oEnv.set( 'VBOX_PATH_QT', sPathBase);
-            g_oEnv.set(f'PATH_SDK_{self.sSdkName}', sPathBase);
+            sPathSdk     = sPathBase;
             sPathBin     = os.path.join(sPathBase, 'bin');
             sPathInc     = os.path.join(sPathBase, 'include');
             sPathLib     = os.path.join(sPathBase, 'lib');
             sPathLibExec = os.path.join(sPathBase, 'libexec');
+            if self.enmBuildTarget == BuildTarget.DARWIN:
+                sPathQtData = os.path.join(sPathBase, 'share', 'qt');
+                if isDir(os.path.join(sPathQtData, 'plugins')):
+                    sPathSdk = sPathQtData;
+                sPathQtLibExec = os.path.join(sPathQtData, 'libexec');
+                if isDir(sPathQtLibExec):
+                    sPathLibExec = sPathQtLibExec;
+            g_oEnv.set(f'PATH_SDK_{self.sSdkName}', sPathSdk);
 
             if self.enmBuildTarget != BuildTarget.WINDOWS:
                 # Tell g++ that we need C++17 -- otherwise Qt6 won't compile.

--- a/src/VBox/Frontends/VirtualBox/src/settings/editors/UIHostComboEditor.cpp
+++ b/src/VBox/Frontends/VirtualBox/src/settings/editors/UIHostComboEditor.cpp
@@ -147,19 +147,19 @@ QString UINativeHotKey::toString(int iKeyCode)
     {
         case shiftKey:
         case rightShiftKey:
-            strKeyName = strKeyName.arg(QChar(kShiftUnicode));
+            strKeyName = strKeyName.arg(QChar(static_cast<ushort>(kShiftUnicode)));
             break;
         case optionKey:
         case rightOptionKey:
-            strKeyName = strKeyName.arg(QChar(kOptionUnicode));
+            strKeyName = strKeyName.arg(QChar(static_cast<ushort>(kOptionUnicode)));
             break;
         case controlKey:
         case rightControlKey:
-            strKeyName = strKeyName.arg(QChar(kControlUnicode));
+            strKeyName = strKeyName.arg(QChar(static_cast<ushort>(kControlUnicode)));
             break;
         case cmdKey:
         case kEventKeyModifierRightCmdKeyMask:
-            strKeyName = strKeyName.arg(QChar(kCommandUnicode));
+            strKeyName = strKeyName.arg(QChar(static_cast<ushort>(kCommandUnicode)));
             break;
     }
 

--- a/src/VBox/Main/src-server/darwin/HostDnsServiceDarwin.cpp
+++ b/src/VBox/Main/src-server/darwin/HostDnsServiceDarwin.cpp
@@ -241,6 +241,7 @@ int HostDnsServiceDarwin::updateInfo(void)
         {
             CFStringRef const serverAddressRef = (CFStringRef)CFArrayGetValueAtIndex(serverArrayRef, i);
             if (serverAddressRef)
+            {
                 if (!queryCFStringAsUtf8Str(serverAddressRef, strTmp, _16K))
                 {
                     LogRel(("HostDnsServiceDarwin: idx: %u: Failed to convert address.\n", i));
@@ -273,6 +274,7 @@ int HostDnsServiceDarwin::updateInfo(void)
                 }
                 else
                     LogRel(("HostDnsServiceDarwin: line %u: bad nameserver address %s\n", i, strTmp.c_str()));
+            }
         }
     }
 
@@ -313,4 +315,3 @@ void HostDnsServiceDarwin::Data::performShutdownCallback(void *pInfo)
     AssertPtrReturnVoid(pThis->m);
     ASMAtomicXchgBool(&pThis->m->m_fStop, true);
 }
-

--- a/src/VBox/Main/src-server/darwin/HostPowerDarwin.cpp
+++ b/src/VBox/Main/src-server/darwin/HostPowerDarwin.cpp
@@ -229,7 +229,7 @@ void HostPowerServiceDarwin::checkBatteryCriticalLevel(bool *pfCriticalChanged)
                 result = CFDictionaryGetValueIfPresent(pSource, CFSTR(kIOPSDeadWarnLevelKey), &psValue);
                 if (result)
                     CFNumberGetValue((CFNumberRef)psValue, kCFNumberSInt32Type, &criticalValue);
-                critical = remCapacity < criticalValue;
+                critical = remCapacity < (float)criticalValue;
 
                 /* We have to take action only if we are on battery, the
                  * previous state wasn't critical, the state has changed & the
@@ -249,4 +249,3 @@ void HostPowerServiceDarwin::checkBatteryCriticalLevel(bool *pfCriticalChanged)
     CFRelease(pBlob);
     CFRelease(pSources);
 }
-

--- a/src/VBox/VMM/VMMR3/target-armv8/NEMR3Native-darwin-armv8.cpp
+++ b/src/VBox/VMM/VMMR3/target-armv8/NEMR3Native-darwin-armv8.cpp
@@ -73,7 +73,7 @@
 *   Structures and Typedefs                                                                                                      *
 *********************************************************************************************************************************/
 
-#if MAC_OS_X_VERSION_MIN_REQUIRED < 150000
+#if !__has_include(<Hypervisor/hv_gic_types.h>)
 
 /* Since 15.0+ */
 typedef enum hv_gic_distributor_reg_t : uint16_t
@@ -138,10 +138,15 @@ typedef enum hv_gic_intid_t : uint16_t
     HV_GIC_INT_PERFORMANCE_MONITOR = 30
 } hv_gic_intid_t;
 
-# define HV_SYS_REG_ACTLR_EL1   (hv_sys_reg_t)0xc081
-
 #else
 # define HV_GIC_ICC_REG_INVALID (hv_gic_icc_reg_t)UINT16_MAX
+#endif
+
+#define VBOX_HV_SYS_REG_ACTLR_EL1   (hv_sys_reg_t)0xc081
+
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 150000
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunguarded-availability-new"
 #endif
 
 typedef hv_vm_config_t  FN_HV_VM_CONFIG_CREATE(void);
@@ -192,6 +197,10 @@ typedef hv_return_t     FN_HV_GIC_SET_ICV_REG(hv_vcpu_t vcpu, hv_gic_icv_reg_t r
 typedef hv_return_t     FN_HV_GIC_SET_REDISTRIBUTOR_REG(hv_vcpu_t vcpu, hv_gic_redistributor_reg_t reg, uint64_t value);
 
 typedef hv_return_t     FN_HV_GIC_GET_INTID(hv_gic_intid_t interrupt, uint32_t *intid);
+
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 150000
+# pragma clang diagnostic pop
+#endif
 
 
 /**
@@ -559,7 +568,7 @@ static const struct
     uint32_t        offCpumCtx;
 } s_aCpumSysRegsSequioa[] =
 {
-    { HV_SYS_REG_ACTLR_EL1,         CPUMCTX_EXTRN_SYSREG_MISC,      RT_UOFFSETOF(CPUMCTX, Actlr.u64)        }
+    { VBOX_HV_SYS_REG_ACTLR_EL1,    CPUMCTX_EXTRN_SYSREG_MISC,      RT_UOFFSETOF(CPUMCTX, Actlr.u64)        }
 };
 /** EL2 support system registers. */
 static const struct
@@ -1045,7 +1054,7 @@ static int nemR3DarwinCopyStateFromHv(PVMCC pVM, PVMCPUCC pVCpu, uint64_t fWhat)
              * https://github.com/AsahiLinux/docs/blob/main/docs/hw/cpu/system-registers.md#actlr_el1-arm-standard-not-standard
              * But the ones being set are not documented. Maybe they are always set by the Hypervisor...
              */
-            if (s_aCpumSysRegsSequioa[i].enmHvReg == HV_SYS_REG_ACTLR_EL1)
+            if (s_aCpumSysRegsSequioa[i].enmHvReg == VBOX_HV_SYS_REG_ACTLR_EL1)
                 *pu64 &= RT_BIT_64(1);
         }
     }
@@ -3476,4 +3485,3 @@ VMM_INT_DECL(uint32_t) NEMHCGetFeatures(PVMCC pVM)
  *
  * @todo Add notes as the implementation progresses...
  */
-

--- a/src/libs/xpcom18a4/ipc/ipcd/client/src/ipcDConnectService.cpp
+++ b/src/libs/xpcom18a4/ipc/ipcd/client/src/ipcDConnectService.cpp
@@ -58,6 +58,7 @@
 # include <iprt/mem.h>
 # include <iprt/time.h>
 # include <iprt/thread.h>
+# include <iprt/utf16.h>
 
 # include <VBox/log.h>
 #endif /* VBOX */
@@ -390,7 +391,7 @@ SerializeParam(PIPCMSGWRITER pMsgWriter, const nsXPTType &t, const nsXPTCMiniVar
       {
         if (v.val.p)
         {
-          int len = 2 * nsCRT::strlen((const PRUnichar *) v.val.p);
+          PRUint32 len = (PRUint32)(RTUtf16Len((PCRTUTF16)v.val.p) * sizeof(RTUTF16));
           IPCMsgWriterPutU32(pMsgWriter, len);
           IPCMsgWriterPutBytes(pMsgWriter, v.val.p, len);
         }
@@ -538,11 +539,11 @@ DeserializeParam(PIPCMSGREADER pMsgReader, const nsXPTType &t, nsXPTCVariant &v)
         }
         else
         {
-          PRUnichar *buf = (PRUnichar *)RTMemAlloc(len + 2);
+          PRTUTF16 buf = (PRTUTF16)RTMemAlloc(len + sizeof(RTUTF16));
           IPCMsgReaderReadBytes(pMsgReader, buf, len);
-          buf[len / 2] = PRUnichar(0);
+          buf[len / sizeof(RTUTF16)] = RTUTF16(0);
 
-          v.val.p = buf;
+          v.val.p = (PRUnichar *)buf;
           v.SetValIsAllocated();
         }
       }
@@ -786,11 +787,11 @@ DeserializeResult(PIPCMSGREADER pMsgReader, const nsXPTType &t, nsXPTCMiniVarian
         }
         else
         {
-          PRUnichar *buf = (PRUnichar *)RTMemAlloc(len + 2);
+          PRTUTF16 buf = (PRTUTF16)RTMemAlloc(len + sizeof(RTUTF16));
           IPCMsgReaderReadBytes(pMsgReader, buf, len);
-          buf[len / 2] = PRUnichar(0);
+          buf[len / sizeof(RTUTF16)] = RTUTF16(0);
 
-          *((PRUnichar **) v.val.p) = buf;
+          *((PRUnichar **) v.val.p) = (PRUnichar *)buf;
         }
       }
       break;

--- a/src/libs/xpcom18a4/xpcom/glue/nsGenericFactory.cpp
+++ b/src/libs/xpcom18a4/xpcom/glue/nsGenericFactory.cpp
@@ -374,10 +374,12 @@ nsGenericModule::GetClassObject(nsIComponentManager *aCompMgr,
     const nsModuleComponentInfo* desc = mComponents;
     for (PRUint32 i = 0; i < mComponentCount; i++) {
         if (desc->mCID.Equals(aClass)) {
-            nsCOMPtr<nsIGenericFactory> fact;
-            rv = NS_NewGenericFactory(getter_AddRefs(fact), desc);
+            nsIGenericFactory *fact = NULL;
+            rv = NS_NewGenericFactory(&fact, desc);
             if (NS_FAILED(rv)) return rv;
-            return fact->QueryInterface(aIID, r_classObj);
+            rv = fact->QueryInterface(aIID, r_classObj);
+            NS_RELEASE(fact);
+            return rv;
         }
         desc++;
     }


### PR DESCRIPTION
## Summary

Make a current macOS/Arm source build work with the selected Apple SDK and Homebrew Qt 6, then keep its XPCOM management path usable with the current Clang ABI.

The pull request has four focused commits.

### 1. Configure and Qt layout

- pass the selected macOS SDK to Darwin compile probes with `-isysroot`;
- search the SDK C++ headers before Homebrew's fallback `include/c++`;
- treat an explicit Darwin `--with-qt-path` as a framework root;
- derive framework header and `-F` paths from `QtCore.framework`;
- detect Homebrew Qt tools in `share/qt/libexec` and plugins in `share/qt/plugins`.

### 2. Compiler-proven source blockers

- avoid redefining macOS 15 GIC types when the SDK already provides them, while retaining old-SDK fallbacks and dynamic runtime gating;
- use an unannotated local value for the dynamically supported ACTLR register;
- make the battery threshold float conversion explicit;
- cast Carbon hot-key Unicode constants to the Qt `QChar` storage type;
- brace the DNS server-address block, fixing the warning and preventing stale-value parsing for a null array entry.

### 3. XPCOM generic-factory output

With the clean build, `VBoxManage --version` worked but `VBoxManage list vms` reproducibly exited on SIGSEGV. Both `VBoxManage` and `VBoxSVC` crashed in `nsGenericModule::GetClassObject` at the factory `QueryInterface` call because the generated current-Clang code dereferenced a null smart pointer after the aliased output call.

Use a raw temporary only for the factory output, query it, and release it. This preserves the ownership transfer while removing the aliased smart-pointer output.

### 4. XPCOM IPC UTF-16 width

After the factory crash was removed, `VBoxManage list vms` returned a truncated name and UUID:

```text
"Win" {d486670d-120b-40b6-}
```

The IPC wire format is UTF-16, but the legacy `PRUnichar` assumptions do not reliably remain two bytes in this current Darwin component build. Measure, allocate, terminate, and copy with IPRT's fixed-width `RTUTF16` types while preserving the existing XPCOM-facing pointer type.

## Scope

Every configure/source change corresponds to a clean-build compiler failure or an exact management-command runtime failure on macOS/Arm with SDK 26.5 and Qt 6.11.1. The Hypervisor availability handling remains compile-time-only; the macOS 15 APIs continue to be resolved and gated dynamically at runtime.

Non-Darwin configure behavior and Oracle/devtools Qt layouts are unchanged. The factory ownership sequence is semantically unchanged, and the IPC change makes the existing two-byte wire contract explicit.

## Reproduction and validation

Configure:

```sh
./configure.py --disable-hardening \
  --with-kbuild-path=/path/to/kBuild \
  --with-macossdk-path=$(xcrun --sdk macosx --show-sdk-path) \
  --with-xcode-path=/Library/Developer/CommandLineTools \
  --with-qt-path=/opt/homebrew/opt/qt
```

Validated results:

- `git diff --check` and `python3 -m py_compile configure.py` pass.
- A clean configure succeeds with SDK 26.5 and Homebrew Qt 6.11.1.
- Generated Qt paths resolve the Homebrew tools/plugins, including `libqcocoa.dylib`.
- A full integrated `kmk -j6` build passed for the configure/compiler changes.
- After the two XPCOM commits, `kmk -j6 VBoxXPCOM VBoxXPCOMIPCC` and the dependent `VirtualBoxVM` target pass.
- The staged arm64 app passes strict deep code-signature verification with the VM hypervisor/JIT entitlements retained.
- `VBoxManage list vms` exits 0 and returns the complete value:

```text
"Win11" {d486670d-120b-40b6-8ef3-24ff3c14ef71}
```

- `VBoxManage showvminfo Win11 --machinereadable` also returns the full name/path and reports the expected `vboxsvga`, 3D-enabled, 256 MiB VRAM configuration.

Refs #742.