### PR TITLE
configure: quote generated shell environment values

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -3209,6 +3209,14 @@ class EnvFileWriter(EnvMgrWriter):
         super().__init__(asFilename, enmBuildTarget, oEnvMgr, cchKeyAlign);
         self.sKeyword = 'set' if enmBuildTarget == BuildTarget.WINDOWS else 'export';
 
+    def formatValue(self, sVal):
+        """
+        Formats an environment variable value for the target shell.
+        """
+        if self.enmBuildTarget == BuildTarget.WINDOWS:
+            return sVal;
+        return shlex.quote(str(sVal));
+
     def write(self, sKey, oVal = None):
         """
         Writes an environment variable appropriate for the platform.
@@ -3220,12 +3228,12 @@ class EnvFileWriter(EnvMgrWriter):
                 sValStr = ' '.join(map(str, oVal));
             else:
                 sValStr = str(oVal);
-            super().write_raw(f"{self.sKeyword} {sKey}={sValStr}");
+            super().write_raw(f"{self.sKeyword} {sKey}={self.formatValue(sValStr)}");
             return;
 
         if  sKey in self.oEnvMgr.env \
         and sKey is not None:
-            super().write_raw(f"{self.sKeyword} {sKey}={oVal if oVal else self.oEnvMgr[sKey]}");
+            super().write_raw(f"{self.sKeyword} {sKey}={self.formatValue(oVal if oVal else self.oEnvMgr[sKey])}");
 
     def write_all(self, asPrefixInclude = None, asPrefixExclude = None):
         """


### PR DESCRIPTION
## Summary

Quote non-Windows generated `env.sh` values before writing `export KEY=value` lines.

This keeps `source ./env.sh` working when inherited environment values contain spaces, for example a `PATH` entry under a macOS `.app` bundle. Windows `env.bat` output is unchanged.

The formatting helper converts the value to a string before passing it to `shlex.quote`, so scalar environment values remain robust as well.

## Reproduction

Without quoting, a generated line such as:

```sh
export PATH=/usr/bin:/Applications/Little Snitch.app/Contents/Components:/bin
```

is parsed as a split assignment and an additional invalid export argument.

## Validation

- Rebased and applied independently to current `origin/main` (`5ac81eda`).
- One file; `git diff --check` and `python3 -m py_compile configure.py` pass.
- Ran a clean Darwin configure with the inherited `PATH` containing `/Applications/Little Snitch.app/Contents/Components`.
- The generated line is shell-quoted; sourcing `env.sh` succeeds and restores the exact original `PATH`, including the space-containing entry.
- The integrated full Darwin/Arm build completed with exit 0 after sourcing that environment **and** supplying the separate kBuild SDK/tool overrides required by the current tree.

## Scope

This PR fixes shell serialization only. It does not claim that all configure SDK selections are propagated into `AutoConfig.kmk`; the current local Darwin build still requires explicit `PATH_SDK_MACOSX*` and tool overrides at `kmk` invocation time.

Closes #750.