### PR TITLE
DXMT: initialize async compile ready flags

### DIFF
--- a/src/libs/dxmt-0.60/src/d3d11/d3d11_pipeline.cpp
+++ b/src/libs/dxmt-0.60/src/d3d11/d3d11_pipeline.cpp
@@ -18,7 +18,7 @@ public:
         num_rtvs(pDesc->NumColorAttachments),
         depth_stencil_format(pDesc->DepthStencilFormat),
         topology_class(pDesc->TopologyClass), device_(pDevice),
-        pBlendState(pDesc->BlendState),
+        ready_(false), pBlendState(pDesc->BlendState),
         RasterizationEnabled(pDesc->RasterizationEnabled),
         SampleCount(pDesc->SampleCount) {
     uint32_t unorm_output_reg_mask = 0;
@@ -163,7 +163,8 @@ class MTLCompiledComputePipeline
     : public ComObject<IMTLCompiledComputePipeline> {
 public:
   MTLCompiledComputePipeline(MTLD3D11Device *pDevice, ManagedShader shader)
-      : ComObject<IMTLCompiledComputePipeline>(), device_(pDevice) {
+      : ComObject<IMTLCompiledComputePipeline>(), device_(pDevice),
+        ready_(false) {
     ComputeShader = shader->get_shader(ShaderVariantDefault{});
   }
 

--- a/src/libs/dxmt-0.60/src/d3d11/d3d11_pipeline_gs.cpp
+++ b/src/libs/dxmt-0.60/src/d3d11/d3d11_pipeline_gs.cpp
@@ -15,7 +15,7 @@ public:
       : ComObject<IMTLCompiledGeometryPipeline>(),
         num_rtvs(pDesc->NumColorAttachments),
         depth_stencil_format(pDesc->DepthStencilFormat), device_(pDevice),
-        pBlendState(pDesc->BlendState),
+        ready_(false), pBlendState(pDesc->BlendState),
         RasterizationEnabled(pDesc->RasterizationEnabled),
         SampleCount(pDesc->SampleCount) {
     uint32_t unorm_output_reg_mask = 0;

--- a/src/libs/dxmt-0.60/src/d3d11/d3d11_pipeline_tess.cpp
+++ b/src/libs/dxmt-0.60/src/d3d11/d3d11_pipeline_tess.cpp
@@ -17,7 +17,7 @@ public:
         num_rtvs(pDesc->NumColorAttachments),
         depth_stencil_format(pDesc->DepthStencilFormat),
         topology_class(pDesc->TopologyClass), device_(pDevice),
-        pBlendState(pDesc->BlendState),
+        ready_(false), pBlendState(pDesc->BlendState),
         RasterizationEnabled(pDesc->RasterizationEnabled),
         SampleCount(pDesc->SampleCount) {
     uint32_t unorm_output_reg_mask = 0;

--- a/src/libs/dxmt-0.60/src/d3d11/d3d11_shader.cpp
+++ b/src/libs/dxmt-0.60/src/d3d11/d3d11_shader.cpp
@@ -11,7 +11,7 @@ public:
   GeneralShaderCompileTask(MTLD3D11Device *pDevice, ManagedShader shader,
                            Proc &&proc)
       : CompiledShader(), proc(std::forward<Proc>(proc)), device_(pDevice),
-        shader_(shader) {}
+        shader_(shader), ready_(false) {}
 
   ~GeneralShaderCompileTask() {}
 


### PR DESCRIPTION
## Summary

Initialize DXMT asynchronous shader and pipeline compile `ready_` flags to `false`.

The affected compile tasks publish a `std::atomic_bool ready_` that callers use before consuming shader or pipeline state. A newly-created task should always begin as not-ready and only become ready when the worker has populated the result.

## Validation

- `git diff --check`
- Cherry-picked on top of #748 and built with `kmk VBoxDxMt` on macOS/Arm using LLVM 15.0.7.

Closes #755.

Signed-off-by: Roberto Nibali <rnibali@gmail.com>
