### PR TITLE
DXMT: keep indexed draw base vertex signed

### DIFF
--- a/src/libs/dxmt-0.60/src/d3d11/d3d11_context_impl.cpp
+++ b/src/libs/dxmt-0.60/src/d3d11/d3d11_context_impl.cpp
@@ -573,7 +573,7 @@ struct DXMT_DRAW_INDEXED_ARGUMENTS {
   uint32_t IndexCount;
   uint32_t InstanceCount;
   uint32_t StartIndex;
-  uint32_t BaseVertex;
+  int32_t BaseVertex;
   uint32_t StartInstance;
 };
 

--- a/src/libs/dxmt-0.60/src/winemetal/winemetal.h
+++ b/src/libs/dxmt-0.60/src/winemetal/winemetal.h
@@ -1178,7 +1178,7 @@ struct wmtcmd_render_draw_indexed {
   obj_handle_t index_buffer;
   uint64_t index_buffer_offset;
   uint32_t instance_count;
-  uint32_t base_vertex;
+  int32_t base_vertex;
   uint32_t base_instance;
 };
 


### PR DESCRIPTION
## Summary

Keep indexed-draw base-vertex values signed across the bundled DXMT/winemetal command boundary.

`BaseVertexLocation` is signed in D3D11, and Metal's indexed-draw `baseVertex` argument is signed. The two intermediate command fields are currently `uint32_t`; this patch changes only those fields to `int32_t`. Their size and command layout remain unchanged.

## Deterministic reproduction

Use an indexed draw with `BaseVertexLocation = -1`.

1. `MTLD3D11DeviceContextImpl::DrawIndexed` receives the correct signed `INT` value.
2. Assigning it to `DXMT_DRAW_INDEXED_ARGUMENTS::BaseVertex` currently stores `0xffffffff` in an unsigned field.
3. Assigning that to `wmtcmd_render_draw_indexed::base_vertex` keeps it unsigned.
4. Objective-C then promotes the field for Metal's signed `baseVertex` parameter as positive `4294967295`, not `-1`.

Keeping both fields signed preserves `-1` through the existing command path.

## Validation

- Rebased independently on current `origin/main` (`5ac81eda`).
- `git diff --check` passes.
- Cherry-picked on top of the LLVM 15 build prerequisite from #748 and built `kmk VBoxDxMt` on macOS/Arm with LLVM 15.0.7.
- Included in the clean integrated macOS/Arm full build, which completed with exit 0 and produced `VBoxDxMt.dylib`.

Closes #754.

Signed-off-by: Roberto Nibali <rnibali@gmail.com>
