### PR TITLE
DXMT: avoid initial data for depth/stencil textures

### DIFF
--- a/src/VBox/Devices/Graphics/DevVGA-SVGA3d-dx-dx11.cpp
+++ b/src/VBox/Devices/Graphics/DevVGA-SVGA3d-dx-dx11.cpp
@@ -3241,9 +3241,14 @@ static int vmsvga3dBackSurfaceCreateResource(PVGASTATECC pThisCC, PVMSVGA3DSURFA
          * On NVidia the host driver does not allow initial data for large textures with D3D11_BIND_DECODER flag.
          */
         D3D11_SUBRESOURCE_DATA *paInitialData = NULL;
+        /* Depth/stencil resources are initialized by subsequent rendering commands
+         * such as clears.  Do not upload the optional host-side backing buffer here:
+         * it may be stale after hardware realization and DXMT's Metal path validates
+         * the source bytes during texture creation.
+         */
         if (   pSurface->paMipmapLevels[0].pSurfaceData
             && pSurface->surfaceDesc.multisampleCount <= 1
-            && (BindFlags & D3D11_BIND_DECODER) == 0
+            && (BindFlags & (D3D11_BIND_DECODER | D3D11_BIND_DEPTH_STENCIL)) == 0
            )
         {
             /* Can happen for a non GBO surface or if GBO texture was updated prior to creation of the hardware resource. */


### PR DESCRIPTION
## Summary

Avoid passing initial host-side backing data when creating DX11 depth/stencil textures in the VMSVGA backend.

Depth/stencil resources are normally initialized by later rendering commands such as clears. On the macOS/Arm DXMT path, passing the optional `pSurfaceData` buffer as initial texture data can crash in Metal's `replaceRegion` validation when that backing memory is stale or otherwise unsuitable for the newly created depth/stencil texture.

## Root cause

`vmsvga3dBackSurfaceCreateResource()` currently passes `paInitialData` whenever `pSurfaceData` is non-null, with exceptions for multisample and decoder resources. The `pSurfaceData` field is optional and documented as potentially outdated after hardware realization. For depth/stencil textures, that upload is unnecessary in the reproduced path and can hand invalid source bytes to DXMT's Metal texture initialization.

## Validation

Tested locally on macOS/Arm with a Windows 11 Arm guest, VMSVGA WDDM, 3D acceleration enabled, and 256 MB VRAM.

Failing run before the change:

- Microsoft Edge WebGL2 workload reached `webgl-context`, then `VirtualBoxVM` aborted.
- Crash report faulted in the `VMSVGA CMD` thread.
- Stack included `AGXMetalG14X agxaAssertBufferIsValid`, `-[AGXG14XFamilyTexture replaceRegion:...]`, `dxmt::InitializeTextureData<D3D11_TEXTURE2D_DESC1>`, `dxCreateTexture`, `vmsvga3dBackSurfaceCreateResource`, and `dxCreateDepthStencilView`.

Passing runs after the change:

- 8 second WebGL2 smoke run completed at 59.9 FPS average.
- 30 second WebGL2 / ANGLE D3D11 run with 512 instances completed at 58.9 FPS average.
- The VM remained running after both runs.

Fixes #763.
