### PR TITLE
GUI: batch framebuffer update notifications

### DIFF
--- a/src/VBox/Frontends/VirtualBox/src/runtime/UIFrameBuffer.cpp
+++ b/src/VBox/Frontends/VirtualBox/src/runtime/UIFrameBuffer.cpp
@@ -77,8 +77,8 @@ signals:
 
     /** Notifies listener about guest-screen resolution changes. */
     void sigNotifyChange(int iWidth, int iHeight);
-    /** Notifies listener about guest-screen updates. */
-    void sigNotifyUpdate(int iX, int iY, int iWidth, int iHeight);
+    /** Notifies listener that one or more guest-screen updates are pending. */
+    void sigNotifyUpdatePending();
     /** Notifies listener about guest-screen visible-region changes. */
     void sigSetVisibleRegion(QRegion region);
 
@@ -262,6 +262,8 @@ public:
 
 protected slots:
 
+    /** Handles coalesced guest-screen updates. */
+    void sltHandlePendingNotifyUpdate();
     /** Handles guest requests to change mouse pointer shape or position. */
     void sltMousePointerShapeOrPositionChange();
 
@@ -274,6 +276,8 @@ protected:
 
     /** Updates coordinate-system: */
     void updateCoordinateSystem();
+    /** Queues a guest-screen update rectangle for asynchronous GUI-thread processing. */
+    void queueNotifyUpdate(ULONG uX, ULONG uY, ULONG uWidth, ULONG uHeight);
 
     /** Default paint routine. */
     void paintDefault(QPaintEvent *pEvent);
@@ -312,6 +316,10 @@ protected:
     CDisplaySourceBitmap m_pendingSourceBitmap;
     /** Holds whether there is a pending source bitmap which must be applied. */
     bool m_fPendingSourceBitmap;
+    /** Holds the coalesced pending guest-screen update region. */
+    QRegion m_pendingUpdateRegion;
+    /** Holds whether a pending-update flush has already been queued. */
+    bool m_fNotifyUpdatePending;
 
     /** Holds machine-view this frame-buffer is bounded to. */
     UIMachineView *m_pMachineView;
@@ -391,6 +399,7 @@ UIFrameBufferPrivate::UIFrameBufferPrivate()
     : m_uScreenId(0)
     , m_iWidth(0), m_iHeight(0)
     , m_fPendingSourceBitmap(false)
+    , m_fNotifyUpdatePending(false)
     , m_pMachineView(NULL)
     , m_iWinId(0)
     , m_fUpdatesAllowed(false)
@@ -695,7 +704,7 @@ STDMETHODIMP UIFrameBufferPrivate::NotifyUpdate(ULONG uX, ULONG uY, ULONG uWidth
     LogRel3(("GUI: UIFrameBufferPrivate::NotifyUpdate: Origin=%lux%lu, Size=%lux%lu, Sending to async-handler\n",
              (unsigned long)uX, (unsigned long)uY,
              (unsigned long)uWidth, (unsigned long)uHeight));
-    emit sigNotifyUpdate(uX, uY, uWidth, uHeight);
+    queueNotifyUpdate(uX, uY, uWidth, uHeight);
 
     /* Unlock access to frame-buffer: */
     unlock();
@@ -748,7 +757,7 @@ STDMETHODIMP UIFrameBufferPrivate::NotifyUpdateImage(ULONG uX, ULONG uY,
         LogRel3(("GUI: UIFrameBufferPrivate::NotifyUpdateImage: Origin=%lux%lu, Size=%lux%lu, Sending to async-handler\n",
                  (unsigned long)uX, (unsigned long)uY,
                  (unsigned long)uWidth, (unsigned long)uHeight));
-        emit sigNotifyUpdate(uX, uY, uWidth, uHeight);
+        queueNotifyUpdate(uX, uY, uWidth, uHeight);
     }
 
     /* Unlock access to frame-buffer: */
@@ -1221,8 +1230,8 @@ void UIFrameBufferPrivate::prepareConnections()
     connect(this, &UIFrameBufferPrivate::sigNotifyChange,
             m_pMachineView, &UIMachineView::sltHandleNotifyChange,
             Qt::QueuedConnection);
-    connect(this, &UIFrameBufferPrivate::sigNotifyUpdate,
-            m_pMachineView, &UIMachineView::sltHandleNotifyUpdate,
+    connect(this, &UIFrameBufferPrivate::sigNotifyUpdatePending,
+            this, &UIFrameBufferPrivate::sltHandlePendingNotifyUpdate,
             Qt::QueuedConnection);
     connect(this, &UIFrameBufferPrivate::sigSetVisibleRegion,
             m_pMachineView, &UIMachineView::sltHandleSetVisibleRegion,
@@ -1240,8 +1249,8 @@ void UIFrameBufferPrivate::cleanupConnections()
     /* Detach EMT connections: */
     disconnect(this, &UIFrameBufferPrivate::sigNotifyChange,
                m_pMachineView, &UIMachineView::sltHandleNotifyChange);
-    disconnect(this, &UIFrameBufferPrivate::sigNotifyUpdate,
-               m_pMachineView, &UIMachineView::sltHandleNotifyUpdate);
+    disconnect(this, &UIFrameBufferPrivate::sigNotifyUpdatePending,
+               this, &UIFrameBufferPrivate::sltHandlePendingNotifyUpdate);
     disconnect(this, &UIFrameBufferPrivate::sigSetVisibleRegion,
                m_pMachineView, &UIMachineView::sltHandleSetVisibleRegion);
 
@@ -1264,6 +1273,52 @@ void UIFrameBufferPrivate::updateCoordinateSystem()
     /* Take the device-pixel-ratio into account: */
     if (useUnscaledHiDPIOutput())
         m_transform = m_transform.scale(1.0 / devicePixelRatio(), 1.0 / devicePixelRatio());
+}
+
+void UIFrameBufferPrivate::queueNotifyUpdate(ULONG uX, ULONG uY, ULONG uWidth, ULONG uHeight)
+{
+    const QRect rect((int)uX, (int)uY, (int)uWidth, (int)uHeight);
+    if (rect.isEmpty())
+        return;
+
+    m_pendingUpdateRegion |= rect;
+    if (!m_fNotifyUpdatePending)
+    {
+        m_fNotifyUpdatePending = true;
+        emit sigNotifyUpdatePending();
+    }
+}
+
+void UIFrameBufferPrivate::sltHandlePendingNotifyUpdate()
+{
+    if (!m_pMachineView)
+    {
+        lock();
+        m_pendingUpdateRegion = QRegion();
+        m_fNotifyUpdatePending = false;
+        unlock();
+        return;
+    }
+
+    lock();
+
+    if (   m_fUnused
+        || m_pendingUpdateRegion.isEmpty())
+    {
+        m_pendingUpdateRegion = QRegion();
+        m_fNotifyUpdatePending = false;
+        unlock();
+        return;
+    }
+
+    const QRegion updateRegion = m_pendingUpdateRegion;
+    m_pendingUpdateRegion = QRegion();
+    m_fNotifyUpdatePending = false;
+
+    unlock();
+
+    for (QRegion::const_iterator it = updateRegion.begin(); it != updateRegion.end(); ++it)
+        m_pMachineView->sltHandleNotifyUpdate(it->x(), it->y(), it->width(), it->height());
 }
 
 void UIFrameBufferPrivate::paintDefault(QPaintEvent *pEvent)


### PR DESCRIPTION
## Summary

Coalesce overlapping guest framebuffer update notifications in the Qt frontend before forwarding them to the machine view.

- Accumulate `NotifyUpdate` and `NotifyUpdateImage` rectangles in a `QRegion` while holding the framebuffer's existing lock.
- Queue at most one GUI-thread callback while a flush is pending.
- Drain the accumulated region under the same lock, then forward each non-overlapping region rectangle through the existing `UIMachineView::sltHandleNotifyUpdate` path.

The change is confined to `UIFrameBuffer.cpp`; it does not alter painting policy, widget attributes, or the dirty-rectangle coordinate conversion.

## Why

This is a draft performance candidate. The macOS/Arm VMSVGA DX11 path can emit bursts of guest updates at HiDPI and 4K sizes. Coalescing overlapping rectangles may reduce queued cross-thread signal traffic without changing the existing view-update path.

No performance benefit is claimed yet. The PR should remain draft—and should be closed if it does not show a repeatable improvement in an isolated current-main A/B comparison.

## Validation

- `git diff --check`
- Full clean Darwin/Arm64 build from current `origin/main` at this minimized patch tip: pending in the pinned comparison build.
- Static concurrency audit: producers update the region under the framebuffer's existing lock; the GUI callback copies and clears it under that lock, releases the lock before calling the machine view, and a producer arriving after the clear queues the next callback.
- Runtime correctness and isolated performance A/B: pending with the fixed [`dxmtbench`](https://github.com/moreaki/dxmtbench) functional gate at 3840x2160 in a Windows 11 Arm guest.

The performance comparison will use identical current-main-based builds and will treat any rendering, signature, context, launch, or graphics-log alert as a failed sample rather than performance evidence.

## Additional lifecycle gate

The coalescing callback is queued to `UIFrameBufferPrivate` and then forwards through the current raw `m_pMachineView` after releasing the framebuffer lock. The former queued signal used the machine view itself as the Qt receiver, so view destruction automatically discarded pending deliveries. Before this draft can be considered valid, it must therefore also survive repeated windowed/fullscreen view replacement and shutdown while updates are queued, with no stale rectangle delivered to a replacement view and no use-after-free. A 4K steady-state benchmark alone is insufficient for that lifecycle check.