### PR TITLE
GUI: fix use-after-free crash in Qt accessibility cache after host work-area changes

### DIFF
--- a/src/VBox/Frontends/VirtualBox/src/globals/UIDesktopWidgetWatchdog.cpp
+++ b/src/VBox/Frontends/VirtualBox/src/globals/UIDesktopWidgetWatchdog.cpp
@@ -919,8 +919,11 @@ void UIDesktopWidgetWatchdog::sltHandleHostScreenAvailableGeometryCalculated(int
             iHostScreenIndex, availableGeometry.x(), availableGeometry.y(),
             availableGeometry.width(), availableGeometry.height()));
 
-    /* Forget finished worker: */
-    pWorker->disconnect();
+    /* Forget finished worker; disconnect only our own connections, a wildcard
+     * disconnect would also sever the destroyed() connection Qt's accessibility
+     * cache relies upon to invalidate cached interfaces, causing a use-after-free
+     * in QAccessibleWidget::text later on: */
+    pWorker->disconnect(this);
     pWorker->deleteLater();
     m_availableGeometryWorkers[iHostScreenIndex] = 0;
 
@@ -1072,7 +1075,9 @@ void UIDesktopWidgetWatchdog::updateHostScreenAvailableGeometry(int iHostScreenI
         QWidget *pOldWorker = m_availableGeometryWorkers.value(iHostScreenIndex);
         if (pOldWorker)
         {
-            pOldWorker->disconnect();
+            /* Disconnect only our own connections, see
+             * sltHandleHostScreenAvailableGeometryCalculated for details: */
+            pOldWorker->disconnect(this);
             pOldWorker->deleteLater();
         }
         m_availableGeometryWorkers[iHostScreenIndex] = pWorker;
@@ -1102,7 +1107,9 @@ void UIDesktopWidgetWatchdog::cleanupExistingWorkers()
     {
         if (pWorker)
         {
-            pWorker->disconnect();
+            /* Disconnect only our own connections, see
+             * sltHandleHostScreenAvailableGeometryCalculated for details: */
+            pWorker->disconnect(this);
             pWorker->deleteLater();
         }
     }


### PR DESCRIPTION
## Summary

Fixes the host-side GUI segfault tracked in #696 (also reported downstream as [Ubuntu bug #2127740](https://bugs.launchpad.net/ubuntu/+source/virtualbox/+bug/2127740) and on [Fedora discussion](https://discussion.fedoraproject.org/t/virtualbox-7-2-4-still-segfault-in-fedora-43-on-libqt6widgets/172829)): both `VirtualBox` and `VirtualBoxVM` crash in `libQt6Widgets` after host display/work-area transitions (screen lock/unlock on GNOME Wayland, external monitor power-off, suspend/resume), leaving running VMs in an "Aborted" state.

## Root cause

`UIDesktopWidgetWatchdog` recreates its per-screen `UIInvisibleWindow` workers on every host work-area change, dropping the old worker with a **wildcard** `QObject::disconnect()` followed by `deleteLater()` (three sites in `UIDesktopWidgetWatchdog.cpp`).

A wildcard disconnect severs *all* of the widget's signal connections — including the `destroyed()` connection that Qt's internal `QAccessibleCache` uses to invalidate cached accessible interfaces (the VirtualBox GUI installs `QAccessible` factories unconditionally, so interfaces get created and cached even when no screen reader is active). Qt 6.10 added a diagnostic for exactly this hazard, which appears in the journal immediately before every crash:

```
QObject::disconnect: wildcard call disconnects from destroyed signal of UIInvisibleWindow::unnamed
```

With that connection severed, the cache keeps a stale `QAccessibleWidget` for the deleted worker. Because workers are recreated repeatedly, a subsequent allocation reuses the freed heap address, the cache lookup returns the stale interface, and `QAccessibleWidget::text(QAccessible::Name)` invokes `QWidget::accessibleName()` on a null widget pointer. `accessibleName()` reads the object's `d_ptr` at offset 8, producing the reported signature:

```
VirtualBox[774940]: segfault at 8 ip ... error 4 in libQt6Widgets.so.6.10.2[1f8024,...+4c8000]
```

Offset `0x1f8024` in Qt 6.10.2's `libQt6Widgets` is the first dereferencing instruction of `QWidget::accessibleName()` (`mov 0x8(%rsi),%rcx`), confirming the null-`this` call. The mechanism is version-independent (`QAccessibleCache` has relied on `destroyed()` since early Qt 6), matching reports against Qt 6.9 as well; Qt 6.10 merely made the hazard visible via the warning.

## Fix

Scope the three disconnects to the watchdog itself (`pWorker->disconnect(this)`). The only connection the watchdog makes on these workers is `sigHostScreenAvailableGeometryCalculated` → watchdog, so the change is behavior-preserving for VirtualBox while Qt-internal connections (accessibility cache, and any other `destroyed()` listeners) survive until the object is actually deleted and the cache invalidates normally.

## Validation

Reproduction (Ubuntu 26.04 GNOME/Wayland, VirtualBox 7.2.10, Qt 6.10.2): run a VM and cycle session lock/unlock (or power an external monitor off/on, or shut the VM down). Each work-area transition prints the wildcard-disconnect warning above, and after a few cycles `VirtualBox` and/or `VirtualBoxVM` segfault with the `ip` offset resolving to `QWidget::accessibleName()`.

The root-cause chain was verified at the binary level (crash offset disassembly, `QAccessibleCache::insert`'s `destroyed()` connection, the Qt 6.10 warning source). I have not yet rebuilt the GUI to exercise the patched path; expected observable results are that the `UIInvisibleWindow` wildcard-disconnect warnings disappear and repeated display transitions no longer crash, while work-area recalculation keeps functioning (`GUI: UIDesktopWidgetWatchdog::sltHandleHostScreenAvailableGeometryCalculated` log lines still appear).

Fixes #696
