### PR TITLE
FE/Qt: Place the full-screen mini-toolbar on the machine window's monitor

### DIFF
--- a/src/VBox/Frontends/VirtualBox/src/widgets/UIMiniToolBar.cpp
+++ b/src/VBox/Frontends/VirtualBox/src/widgets/UIMiniToolBar.cpp
@@ -910,7 +910,10 @@ void UIMiniToolBar::sltAdjust()
 
     /* Get corresponding host-screen: */
     const int iHostScreenCount = UIDesktopWidgetWatchdog::screenCount();
-    int iHostScreen = UIDesktopWidgetWatchdog::screenNumber(m_pParent);
+    /* Resolve the host-screen from the parent's assigned geometry rather than from
+     * its native QWindow association, which can still lag behind the geometry set by
+     * UIMachineWindowFullscreen::placeOnScreen() during a full-screen transition: */
+    int iHostScreen = UIDesktopWidgetWatchdog::screenNumber(m_pParent->geometry().center());
     // WORKAROUND:
     // When switching host-screen count, especially in complex cases where RDP client is "replacing" host-screen(s) with own virtual-screen(s),
     // Qt could behave quite arbitrary and laggy, and due to racing there could be a situation when QDesktopWidget::screenNumber() returns -1


### PR DESCRIPTION
Fixes #842.

## Problem

In full-screen mode the mini-tool-bar's outer window can be placed on a
different host monitor than the machine window it belongs to. That window is
screen-sized and carries `_NET_WM_STATE_FULLSCREEN`, so the window manager
treats the unrelated monitor as holding a full-screen window and desktop panels
on it stop being painted for as long as the VM runs.

Observed with one guest screen on a three-monitor X11 host: the machine window
is correctly on DP-2 (+1920+0) while the tool-bar lands on DP-4 (+3840+0), and
`VBox.log` records `Move mini-toolbar for window #0 to 0x0`.

## Cause

`UIMiniToolBar::sltAdjust()` resolved its host screen with
`UIDesktopWidgetWatchdog::screenNumber(m_pParent)`, which goes through
`m_pParent->windowHandle()->screen()`. During the full-screen transition that
native association can still lag behind the geometry already assigned to the
top-level widget by `UIMachineWindowFullscreen::placeOnScreen()`.

The surrounding code already treats this area as racy — the existing
`WORKAROUND` comment just below handles `screenNumber()` returning -1.

## Change

Resolve the screen from the parent's geometry instead, using the existing
`screenNumber(const QPoint &)` overload. `sltAdjust()` is queued from the
parent's show event, i.e. after `placeOnScreen()` has moved the parent, so its
geometry is authoritative at that point.

## Validation

Arch Linux, X11, Cinnamon 6.6.9/Muffin 6.6.3, three 1920x1200 monitors,
VirtualBox 7.2.16, Qt 6.11.2. Guest with `monitorcount=1`,
`GUI/Fullscreen=true`, mini-tool-bar enabled.

| | stock | patched |
|---|---|---|
| logged tool-bar move | `0x0` | `1920x0` |
| tool-bar window position | `3840,0` | `1920,0` |
| machine window position | `1920,0` | `1920,0` |
| host monitors full-screen | two | one |
| unrelated desktop panel | not painted | painted |

To reproduce without the patch: start a single-screen guest full-screen on a
multi-monitor host where Qt's screen order differs from the window manager's,
and observe the panel on another monitor stop being drawn. Setting
`GUI/ShowMiniToolBar=false` makes it return, confirming which window is
responsible.