### PR TITLE
FE/Qt: Do not wildcard-disconnect the synthetic work-area workers

### DIFF
--- a/src/VBox/Frontends/VirtualBox/src/globals/UIDesktopWidgetWatchdog.cpp
+++ b/src/VBox/Frontends/VirtualBox/src/globals/UIDesktopWidgetWatchdog.cpp
@@ -920,7 +920,10 @@ void UIDesktopWidgetWatchdog::sltHandleHostScreenAvailableGeometryCalculated(int
             availableGeometry.width(), availableGeometry.height()));
 
     /* Forget finished worker: */
-    pWorker->disconnect();
+    disconnect(static_cast<UIInvisibleWindow *>(pWorker),
+               &UIInvisibleWindow::sigHostScreenAvailableGeometryCalculated,
+               this,
+               &UIDesktopWidgetWatchdog::sltHandleHostScreenAvailableGeometryCalculated);
     pWorker->deleteLater();
     m_availableGeometryWorkers[iHostScreenIndex] = 0;
 
@@ -1072,7 +1075,10 @@ void UIDesktopWidgetWatchdog::updateHostScreenAvailableGeometry(int iHostScreenI
         QWidget *pOldWorker = m_availableGeometryWorkers.value(iHostScreenIndex);
         if (pOldWorker)
         {
-            pOldWorker->disconnect();
+            disconnect(static_cast<UIInvisibleWindow *>(pOldWorker),
+                       &UIInvisibleWindow::sigHostScreenAvailableGeometryCalculated,
+                       this,
+                       &UIDesktopWidgetWatchdog::sltHandleHostScreenAvailableGeometryCalculated);
             pOldWorker->deleteLater();
         }
         m_availableGeometryWorkers[iHostScreenIndex] = pWorker;
@@ -1102,7 +1108,10 @@ void UIDesktopWidgetWatchdog::cleanupExistingWorkers()
     {
         if (pWorker)
         {
-            pWorker->disconnect();
+            disconnect(static_cast<UIInvisibleWindow *>(pWorker),
+                       &UIInvisibleWindow::sigHostScreenAvailableGeometryCalculated,
+                       this,
+                       &UIDesktopWidgetWatchdog::sltHandleHostScreenAvailableGeometryCalculated);
             pWorker->deleteLater();
         }
     }


### PR DESCRIPTION
Fixes #397. Likely also covers #658 and #633, which are the same crash reached
by a shell restart or screen lock changing the host work area.

## Problem

r173930 / 700da74f introduced this teardown for the `UIInvisibleWindow` helpers
that measure host-screen available geometry:

```cpp
pWorker->disconnect();
pWorker->deleteLater();
```

The no-argument `disconnect()` is a wildcard: it also removes Qt's internal
`destroyed()` connections. Qt warns about exactly this:

```
QObject::disconnect: wildcard call disconnects from destroyed signal of
UIInvisibleWindow::unnamed
```

With that bookkeeping gone, any host work-area change can crash the frontend
while the replacement worker is being created:

```
QAccessibleWidget::text(QAccessible::Text) const
QWidgetPrivate::setWindowTitle_sys(QString const&)
QWidgetPrivate::setWindowModified_helper()
QWidgetPrivate::create()
QWidget::showMaximized()
UIDesktopWidgetWatchdog::sltHandleHostScreenWorkAreaResized(QRect const&)
QGuiApplicationPrivate::processScreenGeometryChange(...)
```

Notably this needs no monitor hotplug, suspend/resume or DPMS transition. On
X11 an ordinary `_NET_WORKAREA` change is enough — toggling a desktop panel's
autohide reproduces it on the first attempt, which is why reports involving
shell restarts (#658) and screen locks (#633) look unrelated but are not.

`QT_ACCESSIBILITY=0` is sometimes suggested as a workaround; it has no effect
on Qt 6, where the AT-SPI bridge is brought up over D-Bus regardless.

## Change

Disconnect only the signal actually connected here —
`UIInvisibleWindow::sigHostScreenAvailableGeometryCalculated` — at all three
worker-lifecycle sites (`sltHandleHostScreenAvailableGeometryCalculated`,
`updateHostScreenAvailableGeometry`, `cleanupExistingWorkers`), keeping the
`deleteLater()` from r173930.

## Validation

Arch Linux, X11, Cinnamon 6.6.9/Muffin 6.6.3, VirtualBox 7.2.16, Qt 6.11.2.
Trigger: toggling panel autohide, moving `_NET_WORKAREA` between 1170 and 1200.

| | stock | patched |
|---|---|---|
| forced work-area cycles | crash on cycle 1 | 6 cycles, no crash |
| new coredumps | 2 | 0 |
| wildcard-disconnect warning | present | absent |

## Note on the wider design

The deeper issue is that the work-area *handler* itself calls
`updateHostScreenAvailableGeometry()`, which creates a real window and
maximises it — so measuring the work area perturbs the work area. This change
makes that survivable; a re-entrancy guard in
`sltHandleHostScreenWorkAreaResized()` would address the shape of it more
directly. I kept to the smaller change because it is the one I could verify.